### PR TITLE
haproxy-ingress: install haproxy-ingress controller via Helm chart

### DIFF
--- a/apps/haproxy-ingress/Chart.yaml
+++ b/apps/haproxy-ingress/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: haproxy-ingress
+description: haproxy ingress controller
+
+type: application
+version: 13.4.0
+
+appVersion: "v0.13.4"
+
+dependencies:
+- name: haproxy-ingress
+  version: 0.13.4
+  repository: https://haproxy-ingress.github.io/charts

--- a/apps/haproxy-ingress/values.yaml
+++ b/apps/haproxy-ingress/values.yaml
@@ -1,0 +1,11 @@
+controller:
+  stats:
+    enabled: true
+    port: 1936
+  metrics:
+    enabled: true
+    embedded: true
+  serviceMonitor:
+    enabled: true
+  logs: # access logs
+    enabled: true


### PR DESCRIPTION
Installation using Helm per instructions at:
https://haproxy-ingress.github.io/docs/getting-started/