### PR TITLE
monitoring: really add the monitoring ingress from #9

### DIFF
--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -5,9 +5,12 @@ metadata:
 
 resources:
   - github.com/bfritz/homelab-apps/vendor/kube-prometheus
-  - ./prometheus_extra/additional-scrape-configs.yaml
-  - ./grafana-notifiers-brad.yaml
   - ./alertmanager-email-brad.yaml
+  - ./alertmanager-ingress.yaml
+  - ./grafana-ingress.yaml
+  - ./grafana-notifiers-brad.yaml
+  - ./prometheus-ingress.yaml
+  - ./prometheus_extra/additional-scrape-configs.yaml
 
 images:
   - name: grafana/grafana


### PR DESCRIPTION
Forgot to include the `Ingress` yaml in the kustomization file in commit 2e37c91.  D'oh.