### PR TITLE
monitoring: enable ICMP probes from the blackbox exporter

### DIFF
--- a/apps/monitoring/blackbox-exporter-configuration.yaml
+++ b/apps/monitoring/blackbox-exporter-configuration.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blackbox-exporter-configuration
+  namespace: monitoring
+data:
+  config.yml: |-
+    "modules":
+      "http_2xx":
+        "http":
+          "preferred_ip_protocol": "ip4"
+        "prober": "http"
+      "http_post_2xx":
+        "http":
+          "method": "POST"
+          "preferred_ip_protocol": "ip4"
+        "prober": "http"
+      "irc_banner":
+        "prober": "tcp"
+        "tcp":
+          "preferred_ip_protocol": "ip4"
+          "query_response":
+          - "send": "NICK prober"
+          - "send": "USER prober prober prober :prober"
+          - "expect": "PING :([^ ]+)"
+            "send": "PONG ${1}"
+          - "expect": "^:[^ ]+ 001"
+      "pop3s_banner":
+        "prober": "tcp"
+        "tcp":
+          "preferred_ip_protocol": "ip4"
+          "query_response":
+          - "expect": "^+OK"
+          "tls": true
+          "tls_config":
+            "insecure_skip_verify": false
+      "ssh_banner":
+        "prober": "tcp"
+        "tcp":
+          "preferred_ip_protocol": "ip4"
+          "query_response":
+          - "expect": "^SSH-2.0-"
+      "tcp_connect":
+        "prober": "tcp"
+        "tcp":
+          "preferred_ip_protocol": "ip4"
+      "icmp":
+        "prober": "icmp"
+        "icmp":
+          "preferred_ip_protocol": "ip4"

--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -75,3 +75,26 @@ patches:
             - name: grafana-notifiers
               configMap:
                 name: grafana-notifiers-brad
+
+  - path: blackbox-exporter-configuration.yaml
+    target:
+      name: blackbox-exporter-configuration
+      kind: ConfigMap
+
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: blackbox-exporter
+        namespace: monitoring
+      spec:
+        template:
+          spec:
+            containers:
+            - name: blackbox-exporter
+              securityContext:
+                runAsUser: 0 # to override the default of 65534 (nobody)
+                runAsNonRoot: false
+                capabilities:
+                  drop: ["ALL"]
+                  add: ["NET_RAW"]


### PR DESCRIPTION
There are two parts to enabling ICMP probes:

1. Add the `icmp` module to the blackbox exporter configuration.
2. Adjust the `securityContext` for the `blackbox-exporter` container to allow sending pings.

For (1), override the default kube-prometheus ConfigMap and add the icmp module.

For (2), patch the Deployment `securityContext` values to run as root with only the `NET_RAW` capability.

References:

* https://github.com/prometheus-operator/kube-prometheus/blob/v0.9.0/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet#L169-L175
* https://github.com/prometheus-operator/kube-prometheus/blob/v0.9.0/docs/blackbox-exporter.md?plain=1#L43
* https://github.com/prometheus-operator/kube-prometheus/pull/778#discussion_r521955739