### PR TITLE
monitoring: support loading Grafana dashboards from labeled ConfigMaps

### DIFF
--- a/apps/monitoring/dashboards/sample.yaml
+++ b/apps/monitoring/dashboards/sample.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-sample
+  namespace: monitoring-dashboards
+  labels:
+    grafana_dashboard: "1"
+data:
+  sample.json: |-
+    {
+      "__inputs": [
+      ],
+      "__requires": [
+      ],
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "Sample of custom dashboard.",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 27,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "datasource": null,
+          "description": "",
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 2,
+          "options": {
+            "content": "Sample of custom dashboard for [bfritz/homelab-apps].\n\nSource at https://github.com/bfritz/homelab-apps/tree/main/apps/monitoring/dashboards/sample.yaml .\n\n[bfritz/homelab-apps]: https://github.com/bfritz/homelab-apps",
+            "mode": "markdown"
+          },
+          "pluginVersion": "8.2.3",
+          "type": "text"
+        }
+      ],
+      "schemaVersion": 31,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Sample Dashboard",
+      "uid": "zu8EeWi1k",
+      "version": 1
+    }

--- a/apps/monitoring/grafana-dashboards-configuration.yaml
+++ b/apps/monitoring/grafana-dashboards-configuration.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards
+  namespace: monitoring
+data:
+  dashboards.yaml: |-
+    {
+        "apiVersion": 1,
+        "providers": [
+            {
+                "folder": "Default",
+                "folderUid": "",
+                "name": "0",
+                "options": {
+                    "path": "/grafana-dashboard-definitions/0"
+                },
+                "orgId": 1,
+                "type": "file"
+            },
+            {
+                "folder": "Custom",
+                "folderUid": "",
+                "name": "cm",
+                "options": {
+                    "path": "/grafana-dashboard-definitions/cm"
+                },
+                "orgId": 1,
+                "type": "file"
+            }
+        ]
+    }

--- a/apps/monitoring/grafana-monitoring-dashboards-namespace.yaml
+++ b/apps/monitoring/grafana-monitoring-dashboards-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring-dashboards

--- a/apps/monitoring/grafana-monitoring-dashboards-view-role.yaml
+++ b/apps/monitoring/grafana-monitoring-dashboards-view-role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: monitoring-dashboard-view
+  namespace: monitoring-dashboards
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - "get"
+  - "list"
+  - "watch"

--- a/apps/monitoring/grafana-rolebinding.yaml
+++ b/apps/monitoring/grafana-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: grafana-monitoring-dashboard-view
+  namespace: monitoring-dashboards
+subjects:
+- kind: ServiceAccount
+  name: grafana
+  namespace: monitoring
+roleRef:
+  kind: Role
+  name: monitoring-dashboard-view
+  apiGroup: rbac.authorization.k8s.io

--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -8,7 +8,10 @@ resources:
   - ./alertmanager-email-brad.yaml
   - ./alertmanager-ingress.yaml
   - ./grafana-ingress.yaml
+  - ./grafana-monitoring-dashboards-namespace.yaml
+  - ./grafana-monitoring-dashboards-view-role.yaml
   - ./grafana-notifiers-brad.yaml
+  - ./grafana-rolebinding.yaml
   - ./probes-key-public-ips.yaml
   - ./prometheus-ingress.yaml
   - ./prometheus_extra/additional-scrape-configs.yaml
@@ -88,7 +91,7 @@ patches:
                 - name: RESOURCE
                   value: "configmap"
                 - name: NAMESPACE
-                  value: "monitoring"
+                  value: "monitoring-dashboards"
                 - name: UNIQUE_FILENAMES
                   value: "true"
               volumeMounts:

--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -17,6 +17,8 @@ images:
   - name: grafana/grafana
     newTag:
     digest: sha256:d6325d20f78cd306b4f8a9d0057ea7022a34d273553034d3d871040c3db37fc3 # 8.2.3 for linux/amd64
+  - name: kiwigrid/k8s-sidecar
+    digest: sha256:35654389f8a9b7816193a4811cf3ceb6cf309ece8874e84b3d2d8399e618059b # 1.14.2
 
 patches:
   - patch: |-
@@ -68,14 +70,38 @@ patches:
               - name: GF_SMTP_HOST
                 value: mail.fewerhassles.com:587
               volumeMounts:
-              - mountPath: /etc/grafana/provisioning/notifiers
-                name: grafana-notifiers
+              - name: grafana-notifiers
+                mountPath: /etc/grafana/provisioning/notifiers
                 readOnly: false
+              - name: sc-dashboard-volume
+                mountPath: "/grafana-dashboard-definitions/cm"
+            - name: grafana-sc-dashboard
+              image: "kiwigrid/k8s-sidecar"
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: METHOD
+                  value: "WATCH"
+                - name: LABEL
+                  value: "grafana_dashboard"
+                - name: FOLDER
+                  value: "/tmp/dashboards"
+                - name: RESOURCE
+                  value: "configmap"
+                - name: NAMESPACE
+                  value: "monitoring"
+                - name: UNIQUE_FILENAMES
+                  value: "true"
+              volumeMounts:
+              - name: sc-dashboard-volume
+                mountPath: "/tmp/dashboards"
             volumes:
             - name: grafana-notifiers
               configMap:
                 name: grafana-notifiers-brad
+            - name: sc-dashboard-volume
+              emptyDir: {}
 
+  # enable ICMP for blackbox-exporter
   - path: blackbox-exporter-configuration.yaml
     target:
       name: blackbox-exporter-configuration
@@ -98,3 +124,9 @@ patches:
                 capabilities:
                   drop: ["ALL"]
                   add: ["NET_RAW"]
+
+  # add supplemental grafana dashboard provider for ConfigMap backed dashboards
+  - path: grafana-dashboards-configuration.yaml
+    target:
+      name: grafana-dashboards
+      kind: ConfigMap


### PR DESCRIPTION
Add support, with [k8s-sidecar], for deploying Grafana dashboards that live as ConfigMaps with the `grafana_dashboard` label.  Copied [from](https://rancher.com/docs/rancher/v2.5/en/monitoring-alerting/guides/persist-grafana/) [rancher](https://github.com/rancher/charts/blob/dev-v2.6/charts/rancher-monitoring/rancher-monitoring/100.1.0%2Bup19.0.3/templates/grafana/configmap-dashboards.yaml#L14-L17).
    
To provision new dashboards, deploy as `ConfigMap` resources into the `monitoring-dashboards` namespace with the `grafana_dashboard` label.
    
[k8s-sidecar]: https://github.com/kiwigrid/k8s-sidecar