### PR TITLE
monitoring: add separate app for the the custom Grafana dashboards

### DIFF
--- a/apps/monitoring/grafana-dashboards-app.yaml
+++ b/apps/monitoring/grafana-dashboards-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: app-grafana-dashboards
+  namespace: argocd
+spec:
+  destination:
+    namespace: monitoring-dashboards
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: apps/monitoring/dashboards
+    repoURL: https://github.com/bfritz/homelab-apps.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated: {}
+    syncOptions:
+    - CreateNamespace=true

--- a/apps/monitoring/grafana-monitoring-dashboards-namespace.yaml
+++ b/apps/monitoring/grafana-monitoring-dashboards-namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: monitoring-dashboards

--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
   - github.com/bfritz/homelab-apps/vendor/kube-prometheus
   - ./alertmanager-email-brad.yaml
   - ./alertmanager-ingress.yaml
+  - ./grafana-dashboards-app.yaml
   - ./grafana-ingress.yaml
-  - ./grafana-monitoring-dashboards-namespace.yaml
   - ./grafana-monitoring-dashboards-view-role.yaml
   - ./grafana-notifiers-brad.yaml
   - ./grafana-rolebinding.yaml


### PR DESCRIPTION
Otherwise, `apps/monitoring/kustomization.yaml` would probably need to explicitly import each of the dashboard ConfigMaps.  Besides, `app-monitoring` is already chunky so keeping the new dashboards in a separate apps should make things easier to review in the Argo CD UI.