### PR TITLE
monitoring: pull in more recent kube-prometheus to update versions

### DIFF
--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -17,9 +17,6 @@ resources:
   - ./prometheus_extra/additional-scrape-configs.yaml
 
 images:
-  - name: grafana/grafana
-    newTag:
-    digest: sha256:d6325d20f78cd306b4f8a9d0057ea7022a34d273553034d3d871040c3db37fc3 # 8.2.3 for linux/amd64
   - name: kiwigrid/k8s-sidecar
     digest: sha256:35654389f8a9b7816193a4811cf3ceb6cf309ece8874e84b3d2d8399e618059b # 1.14.2
 


### PR DESCRIPTION
Updates:

* `grafana` now at 8.2.3 without image kustomization
* `kubeStateMetrics`: 2.2.3 --> 2.2.4
* `prometheus`: 2.30.3 --> 2.31.1
* `prometheusOperator`: 0.51.2 --> 0.52.0