### PR TITLE
monitoring: add ICMP dashboard for the blackbox exporter

### DIFF
--- a/apps/monitoring/dashboards/Makefile
+++ b/apps/monitoring/dashboards/Makefile
@@ -1,0 +1,5 @@
+.PHONY: update
+
+update:
+	@echo Downloading icmp-exporter
+	@curl -Ls "https://gitlab.com/anarcat/grafana-dashboards/-/raw/master/icmp-exporter.json?inline=false" | ./to_yaml.sh icmp-exporter.yaml

--- a/apps/monitoring/dashboards/icmp-exporter.yaml
+++ b/apps/monitoring/dashboards/icmp-exporter.yaml
@@ -1,0 +1,404 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-icmp-exporter
+  namespace: monitoring-dashboards
+  labels:
+    grafana_dashboard: "1"
+data:
+  icmp-exporter.json: |-
+    {
+      "__inputs": [
+        {
+          "name": "DS_LOCALHOST",
+          "label": "localhost",
+          "description": "",
+          "type": "datasource",
+          "pluginId": "prometheus",
+          "pluginName": "Prometheus"
+        }
+      ],
+      "__requires": [
+        {
+          "type": "grafana",
+          "id": "grafana",
+          "name": "Grafana",
+          "version": "6.5.2"
+        },
+        {
+          "type": "panel",
+          "id": "graph",
+          "name": "Graph",
+          "version": ""
+        },
+        {
+          "type": "panel",
+          "id": "heatmap",
+          "name": "Heatmap",
+          "version": ""
+        },
+        {
+          "type": "datasource",
+          "id": "prometheus",
+          "name": "Prometheus",
+          "version": "1.0.0"
+        }
+      ],
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": null,
+      "iteration": 1600696627318,
+      "links": [],
+      "panels": [
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateRdYlGn",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": "prometheus",
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 7,
+          "legend": {
+            "show": true
+          },
+          "options": {},
+          "reverseYBuckets": true,
+          "targets": [
+            {
+              "expr": "sum(probe_icmp_duration_seconds{phase=\"rtt\",instance=~\"$instance\"}) by (instance)",
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "ICMP RTT",
+          "tooltip": {
+            "show": true,
+            "showHistogram": true
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "dtdurations",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "middle",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateRdYlGn",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": "prometheus",
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 8
+          },
+          "heatmap": {},
+          "hideZeroBuckets": false,
+          "highlightCards": true,
+          "id": 8,
+          "legend": {
+            "show": true
+          },
+          "options": {},
+          "reverseYBuckets": true,
+          "targets": [
+            {
+              "expr": "1-avg_over_time(probe_success{instance=~\"$instance\"}[$__interval])",
+              "format": "time_series",
+              "hide": false,
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "ICMP packet loss",
+          "tooltip": {
+            "show": true,
+            "showHistogram": true
+          },
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "percentunit",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "middle",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "decimals": null,
+          "description": "This uses the blackbox exporter, which does not expose packet loss, for example. It could be improved with https://github.com/SuperQ/smokeping_prober because it also keeps track of lost samples (https://github.com/SuperQ/smokeping_prober/issues/24). Unfortunately, that still won't make graphs as nice as smokeping, because each probe only keeps one sample, instead of doing multiple like smokeping does (https://github.com/SuperQ/smokeping_prober/issues/36).",
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 16
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "maxPerRow": 2,
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 0.5,
+          "points": false,
+          "renderer": "flot",
+          "repeat": "instance",
+          "repeatDirection": "v",
+          "seriesOverrides": [
+            {
+              "alias": "packet loss",
+              "color": "#C4162A",
+              "lines": false,
+              "pointradius": 1,
+              "points": true,
+              "yaxis": 2
+            },
+            {
+              "alias": "max RTT",
+              "fillBelowTo": "min RTT",
+              "legend": false,
+              "lines": false
+            },
+            {
+              "alias": "min RTT",
+              "legend": false,
+              "lines": false
+            },
+            {
+              "alias": "RTT",
+              "lines": false
+            },
+            {
+              "alias": "avg RTT",
+              "legend": false
+            },
+            {
+              "alias": "min RTT",
+              "lines": false
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "1-avg_over_time(probe_success{instance=~\"$instance\"}[$__interval])",
+              "format": "time_series",
+              "legendFormat": "packet loss",
+              "refId": "B"
+            },
+            {
+              "expr": "probe_icmp_duration_seconds{phase=\"rtt\",instance=~\"$instance\"} > 0",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "RTT",
+              "refId": "A"
+            },
+            {
+              "expr": "avg_over_time(probe_icmp_duration_seconds{phase=\"rtt\",instance=~\"$instance\"}[5m])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "avg RTT",
+              "refId": "C"
+            },
+            {
+              "expr": "max_over_time(probe_icmp_duration_seconds{phase=\"rtt\",instance=~\"$instance\"}[1m])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "max RTT",
+              "refId": "D"
+            },
+            {
+              "expr": "min_over_time(probe_icmp_duration_seconds{phase=\"rtt\",instance=~\"$instance\"}[1m])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "min RTT",
+              "refId": "E"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "ICMP round trip time ($instance)",
+          "tooltip": {
+            "shared": true,
+            "sort": 1,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "dtdurations",
+              "label": "RTT",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "percentunit",
+              "label": "packet loss",
+              "logBase": 1,
+              "max": "1",
+              "min": "0.0001",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "refresh": false,
+      "schemaVersion": 21,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {},
+            "datasource": "prometheus",
+            "definition": "label_values(probe_success, instance)",
+            "hide": 0,
+            "includeAll": true,
+            "label": null,
+            "multi": true,
+            "name": "instance",
+            "options": [],
+            "query": "label_values(probe_success, instance)",
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ]
+      },
+      "timezone": "",
+      "title": "ICMP exporter",
+      "uid": "oe-msimGz",
+      "version": 9
+    }

--- a/apps/monitoring/dashboards/to_yaml.sh
+++ b/apps/monitoring/dashboards/to_yaml.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+filename="$1"
+name="$(basename "$filename" .yaml)"
+
+cat <<EOF > "$filename"
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-$name
+  namespace: monitoring-dashboards
+  labels:
+    grafana_dashboard: "1"
+data:
+  $name.json: |-
+EOF
+
+# shellcheck disable=SC2016
+cat | sed 's/^/    / ; s/${DS_[A-Z]*}/prometheus/' >> "$filename"
+echo >> "$filename"

--- a/apps/monitoring/probes-key-public-ips.yaml
+++ b/apps/monitoring/probes-key-public-ips.yaml
@@ -4,7 +4,7 @@ metadata:
   name: key-public-ips
   namespace: monitoring
 spec:
-  interval: 60s
+  interval: 5s
   module: icmp
   prober:
     url: blackbox-exporter.monitoring.svc.cluster.local:19115


### PR DESCRIPTION
Follow-up to #14 (and #15) to add a dashboard to visualize the pings to 1.1.1.1 and 8.8.8.8 .

Credit to Antoine Beaupré for the dashboard published at:
https://gitlab.com/anarcat/grafana-dashboards
and:
https://grafana.com/grafana/dashboards/12412

Increased ping rate from 60s to 5s to work more like [smokeping] and produce better visualizations.

[smokeping]: https://oss.oetiker.ch/smokeping/