### PR TITLE
monitoring: fix receiver name in the "email-brad" manifest

### DIFF
--- a/apps/monitoring/alertmanager-email-brad.yaml
+++ b/apps/monitoring/alertmanager-email-brad.yaml
@@ -14,7 +14,7 @@ spec:
       groupWait: 30s
       groupInterval: 5m
       repeatInterval: 2h
-      receiver: 'email-brad'
+      receiver: EmailBrad
   receivers:
   - name: EmailBrad
     emailConfigs:


### PR DESCRIPTION
PR #1 changed the receiver name to "EmailBrad" but did not update the routes to match.