### PR TITLE
monitoring: fix alertmanager email config

### DIFF
--- a/apps/monitoring/alertmanager-email-brad.yaml
+++ b/apps/monitoring/alertmanager-email-brad.yaml
@@ -19,4 +19,5 @@ spec:
   - name: EmailBrad
     emailConfigs:
     - to: "Brad <brad-k8s-alerts-9DrY@fewerhassles.com>"
+      from: Alertmanager <alertmanager@alertmanager.k8s>
       smarthost: "mail.fewerhassles.com:587"


### PR DESCRIPTION
Either a per-config `from` or a global from value is required in the Alertmanager configuration.