### PR TITLE
monitoring: raise CPU limits for blackbox-exporter container

### DIFF
--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -103,7 +103,7 @@ patches:
             - name: sc-dashboard-volume
               emptyDir: {}
 
-  # enable ICMP for blackbox-exporter
+  # enable ICMP for blackbox-exporter and increase CPU limits
   - path: blackbox-exporter-configuration.yaml
     target:
       name: blackbox-exporter-configuration
@@ -120,6 +120,9 @@ patches:
           spec:
             containers:
             - name: blackbox-exporter
+              resources:
+                limits:
+                  cpu: 50m
               securityContext:
                 runAsUser: 0 # to override the default of 65534 (nobody)
                 runAsNonRoot: false


### PR DESCRIPTION
This change is in response to a couple of observations:

1. `CPUThrottlingHigh blackbox-exporter monitoring blackbox-exporter-___ monitoring/k8s info` is fired by Alertmanager.

2. Pings from blackboxk-exporter container have occasional latancy spikes to 100 or 200ms.

100 pings from worker node to NAS server in DMZ:

    k0s-worker:~# ping -q -c 100 nas
    PING nas (172.22.2.150): 56 data bytes

    --- nas ping statistics ---
    100 packets transmitted, 100 packets received, 0% packet loss
    round-trip min/avg/max = 0.289/0.474/2.379 ms
                                         ^^^^^^^^

Maximum is ~2ms when run directly on worker.

100 pings from blackbox-exporter container to same NAS server:

    / # ping -q -c 100 nas
    PING nas (172.22.2.150): 56 data bytes

    --- nas ping statistics ---
    100 packets transmitted, 100 packets received, 0% packet loss
    round-trip min/avg/max = 0.315/12.456/200.068 ms
                                          ^^^^^^^^^^

Maximum is ~200ms when run in the `blackbox-exporter` container.