### PR TITLE
monitoring: raise CPU limits for blackbox-exporter container from 50 to 100m

### DIFF
--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -122,7 +122,7 @@ patches:
             - name: blackbox-exporter
               resources:
                 limits:
-                  cpu: 50m
+                  cpu: 100m
               securityContext:
                 runAsUser: 0 # to override the default of 65534 (nobody)
                 runAsNonRoot: false


### PR DESCRIPTION
See https://github.com/bfritz/homelab-apps/pull/30#issuecomment-978092480 .