### PR TITLE
monitoring: create dedicated TLS cert for Alertmanager

### DIFF
--- a/apps/monitoring/alertmanager-ingress.yaml
+++ b/apps/monitoring/alertmanager-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: monitoring
 spec:
   tls:
-  - secretName: grafana-tls
+  - secretName: alertmanager-tls
     hosts:
     - alertmanager.k8s
   rules:


### PR DESCRIPTION
Fixes copy pasta in #9.