### PR TITLE
haproxy-ingress, metalb: set 172.22.18.32 as private ingress

### DIFF
--- a/apps/argocd/argocd-ingress.yaml
+++ b/apps/argocd/argocd-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: self-signed
     cert-manager.io/common-name: argocd.k8s
-    kubernetes.io/ingress.class: haproxy
+    kubernetes.io/ingress.class: haproxy-private
   name: argocd
   namespace: argocd
 spec:

--- a/apps/haproxy-ingress/values.yaml
+++ b/apps/haproxy-ingress/values.yaml
@@ -1,4 +1,7 @@
 controller:
+  ingressClass: haproxy-private
+  service:
+    loadBalancerIP: 172.22.18.32
   stats:
     enabled: true
     port: 1936

--- a/apps/metallb-system/config.yaml
+++ b/apps/metallb-system/config.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   config: |
     address-pools:
-    - name: default
+    - name: private-pool
       protocol: layer2
       addresses:
       - 172.22.18.32/27

--- a/apps/monitoring/alertmanager-ingress.yaml
+++ b/apps/monitoring/alertmanager-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: self-signed
     cert-manager.io/common-name: alertmanager.k8s
-    kubernetes.io/ingress.class: haproxy
+    kubernetes.io/ingress.class: haproxy-private
   name: alertmanager
   namespace: monitoring
 spec:

--- a/apps/monitoring/grafana-ingress.yaml
+++ b/apps/monitoring/grafana-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: self-signed
     cert-manager.io/common-name: grafana.k8s
-    kubernetes.io/ingress.class: haproxy
+    kubernetes.io/ingress.class: haproxy-private
   name: grafana
   namespace: monitoring
 spec:

--- a/apps/monitoring/prometheus-ingress.yaml
+++ b/apps/monitoring/prometheus-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: self-signed
     cert-manager.io/common-name: prometheus.k8s
-    kubernetes.io/ingress.class: haproxy
+    kubernetes.io/ingress.class: haproxy-private
   name: prometheus
   namespace: monitoring
 spec:


### PR DESCRIPTION
To prepare for ingress that will be exposed publicly, mark 172.22.18.32/27 as a private IP pool and use `haproxy-private` as the ingress class for ingress through 172.22.18.32.