### PR TITLE
haproxy-ingress: properly set Helm values for HAProxy

### DIFF
--- a/apps/haproxy-ingress/Chart.yaml
+++ b/apps/haproxy-ingress/Chart.yaml
@@ -3,7 +3,7 @@ name: haproxy-ingress
 description: haproxy ingress controller
 
 type: application
-version: 13.4.0
+version: 13.4.1
 
 appVersion: "v0.13.4"
 

--- a/apps/haproxy-ingress/values.yaml
+++ b/apps/haproxy-ingress/values.yaml
@@ -1,14 +1,15 @@
-controller:
-  ingressClass: haproxy-private
-  service:
-    loadBalancerIP: 172.22.18.32
-  stats:
-    enabled: true
-    port: 1936
-  metrics:
-    enabled: true
-    embedded: true
-  serviceMonitor:
-    enabled: true
-  logs: # access logs
-    enabled: true
+haproxy-ingress:
+  controller:
+    ingressClass: haproxy-private
+    service:
+      loadBalancerIP: 172.22.18.32
+    stats:
+      enabled: true
+      port: 1936
+    metrics:
+      enabled: true
+      embedded: true
+    serviceMonitor:
+      enabled: true
+    logs: # access logs
+      enabled: true


### PR DESCRIPTION
Values need to be nested under the dependency name, `haproxy-ingress`, otherwise they apply to the empty top-level chart.