### PR TITLE
haproxy-ingress, metalb: add "public" HAProxy ingress at 172.22.18.64

### DIFF
--- a/apps/haproxy-ingress/Chart.yaml
+++ b/apps/haproxy-ingress/Chart.yaml
@@ -9,5 +9,10 @@ appVersion: "v0.13.4"
 
 dependencies:
 - name: haproxy-ingress
+  alias: haproxy-ingress-private
+  version: 0.13.4
+  repository: https://haproxy-ingress.github.io/charts
+- name: haproxy-ingress
+  alias: haproxy-ingress-public
   version: 0.13.4
   repository: https://haproxy-ingress.github.io/charts

--- a/apps/haproxy-ingress/values.yaml
+++ b/apps/haproxy-ingress/values.yaml
@@ -1,8 +1,24 @@
-haproxy-ingress:
+haproxy-ingress-private:
   controller:
     ingressClass: haproxy-private
     service:
       loadBalancerIP: 172.22.18.32
+    stats:
+      enabled: true
+      port: 1936
+    metrics:
+      enabled: true
+      embedded: true
+    serviceMonitor:
+      enabled: true
+    logs: # access logs
+      enabled: true
+
+haproxy-ingress-public:
+  controller:
+    ingressClass: haproxy-public
+    service:
+      loadBalancerIP: 172.22.18.64
     stats:
       enabled: true
       port: 1936

--- a/apps/metallb-system/config.yaml
+++ b/apps/metallb-system/config.yaml
@@ -10,3 +10,7 @@ data:
       protocol: layer2
       addresses:
       - 172.22.18.32/27
+    - name: public-pool
+      protocol: layer2
+      addresses:
+      - 172.22.18.64/27


### PR DESCRIPTION
Run second instance of haproxy-ingress controller that will accept incoming traffic from the Internet.