### PR TITLE
monitoring: use random initial password for gotify admin

### DIFF
--- a/apps/monitoring/Makefile
+++ b/apps/monitoring/Makefile
@@ -1,0 +1,6 @@
+gotify-admin-password.yaml:
+	$(info Use `kubectl -n monitoring get secret gotify-admin -ojson | jq -r '.data.password' | base64 -d` to retrieve password.)
+	openssl rand -base64 15 \
+		| kubectl create secret generic -n monitoring gotify-admin --dry-run=client --from-file=password=/dev/stdin -o json \
+		| kubeseal --format yaml \
+		> gotify-admin-password.yaml

--- a/apps/monitoring/gotify-admin-password.yaml
+++ b/apps/monitoring/gotify-admin-password.yaml
@@ -1,0 +1,16 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: gotify-admin
+  namespace: monitoring
+spec:
+  encryptedData:
+    password: AgCiuX2ZTTL2Xo47yhnBxyU68reb/BEKgEad9vvtRnkSBAkPRkJVYA1L6/CoSl5NzNmFQKq8Z7tD/iaxOOW37HmVnxRLSz9BnYRjNVkz5UhIxicYn5RtlcE5pSC70KfJK6LC18vQ3IwvVVZkEe33St8xAFgAYOxdPGdUR1jP4b3IBEMan8fj24HE2/Jrql+fxjlgIKBTYwNfZUf+DNM0J7xCmGfJrB+uuh9MpP6nBfGGl6M2+yjAH9m01umf4dD9zuvqR6gO9EPIgFtYOj8ixWhfdLv9jkYy6LEPMTa/M1pcCxXvGfEgEoV1IoNsB9n9r/IpqCwxXXnxLIHcU41vGc647zdhWdXEg8VWqBlD3zcMkQbWZkvm48KVDlQLbM2OHv96cqSxV8lyYg3KFh4suOZRqpW1nbSu8lhJyRv+BywuMIVxL23C+usAfPf4A72g/6Vr4unJlgYcessPXj81ZZSTT8BMjB9yLCdKh1oZFJ0sgIBql1d/vaLAbo4/PIRAq4QiKvAKlLQRaxyRSq5F+fbCsYdPVDwfNrpTQxwnjeQNsQPJL6i4pHJF69pJGYCIg0k2hZUl58gUv/79TzVYnf6ZkHfMj1QGDiKkYt7knZo+K+KEFfgco4O8/TZvVXiR9dlLpEEY056HROGn4DZgDcywVqdK2Wjj94wuOsTPKORgyzmmXPfKtXH5yy7nooFg1dVo71qa2t0s8Pdc4tNSaRN5GfZ9r+E=
+  template:
+    data: null
+    metadata:
+      creationTimestamp: null
+      name: gotify-admin
+      namespace: monitoring
+

--- a/apps/monitoring/gotify-deployment.yaml
+++ b/apps/monitoring/gotify-deployment.yaml
@@ -27,6 +27,11 @@ spec:
           value: "data/gotify.db"
         - name: GOTIFY_REGISTRATION
           value: "false"
+        - name: GOTIFY_DEFAULTUSER_PASS
+          valueFrom:
+            secretKeyRef:
+              name: gotify-admin
+              key: password
         ports:
         - containerPort: 8080
           name: http

--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - github.com/bfritz/homelab-apps/vendor/kube-prometheus
   - ./alertmanager-email-brad.yaml
   - ./alertmanager-ingress.yaml
+  - ./gotify-admin-password.yaml
   - ./gotify-deployment.yaml
   - ./gotify-ingress.yaml
   - ./gotify-service.yaml


### PR DESCRIPTION
Retrieve password with:

    kubectl -n monitoring get secret gotify-admin -ojson | jq -r '.data.password' | base64 -d