### PR TITLE
monitoring: set external URLs for Alertmanager and Prometheus

### DIFF
--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -44,6 +44,7 @@ patches:
         additionalScrapeConfigs:
           name: additional-scrape-configs
           key: prometheus-additional.yaml
+        externalUrl: https://prometheus.k8s
 
   - patch: |-
       apiVersion: monitoring.coreos.com/v1
@@ -55,6 +56,7 @@ patches:
         alertmanagerConfigSelector:
           matchLabels:
             alertmanagerConfig: active
+        externalUrl: https://alertmanager.k8s
 
   - patch: |-
       apiVersion: apps/v1


### PR DESCRIPTION
Alertmanager has links to Prometheus and, without the `externalUrl` value set for Prometheus, the links are broken.  Set the Alertmanager URL as well because it's likely to show up in alert emails.

These values match the ones we used in the respective `Ingress` resources.