### PR TITLE
vector-system: scrape prometheus metris from aggregator and agent pods

### DIFF
--- a/apps/vector-system/templates/podmonitors.yaml
+++ b/apps/vector-system/templates/podmonitors.yaml
@@ -1,0 +1,92 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: vector-aggregator-monitor
+  namespace: monitoring
+
+spec:
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vector-aggregator
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: Aggregator
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+    - port: prom-exporter
+      path: /metrics
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: vector-agent-monitor
+  namespace: monitoring
+
+spec:
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vector-agent
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: Agent
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+    - port: prom-exporter
+      path: /metrics
+
+---
+# By default, kube-prometheus RBAC rules allow monitoring in the `monitoring`,
+# `default`, and `kube-system` namespace.  To support `PodMonitor`s in the
+# `vector-system` namespace, we need an additional role and binding in that
+# namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: monitoring
+roleRef:
+  name: prometheus-k8s
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Add `PodMonitor`, and supporting RBAC rules, to scrape the prometheus metrics exported by Vector in both the aggregator and agent pods.

In a simpler world, we'd just use `podMonitor.enable = true` in the chart values.  Unfortunately, that does not address the missing RBAC role binding or allow us to put the `PodMonitor`s into the `monitoring` namespace where our prometheus instances will notice it.