### PR TITLE
database: deploy new Postgres 12 instance with bitnami image

### DIFF
--- a/apps/database/Chart.yaml
+++ b/apps/database/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: database
+description: Databases that require persistant storage and fast disks.
+
+type: application
+version: 0.0.1
+
+dependencies:
+- name: postgresql
+  alias: pg12
+  version: 10.16.1
+  repository: https://charts.bitnami.com/bitnami

--- a/apps/database/templates/backup_cronjob.yaml
+++ b/apps/database/templates/backup_cronjob.yaml
@@ -1,0 +1,39 @@
+# hourly backup of pg12 database to NAS volume
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: pg12-backup
+spec:
+  schedule: "12 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 600
+  failedJobsHistoryLimit: 10
+  successfulJobsHistoryLimit: 36
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 1200
+      template:
+        spec:
+          containers:
+          - name: pg12-backup
+            image: bitnami/postgresql:12.9.0-debian-10-r62
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            args:
+            - -c
+            - /opt/bitnami/postgresql/bin/pg_dumpall -h db-pg12 -U postgres > /backup/pg12_dump_$(date -u +%H).sql
+            env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-pg12
+                  key: postgresql-password
+            volumeMounts:
+              - name: pg12-backup
+                mountPath: /backup
+          volumes:
+            - name: pg12-backup
+              persistentVolumeClaim:
+                claimName: pg12-backup-claim
+          restartPolicy: OnFailure

--- a/apps/database/templates/storage.yaml
+++ b/apps/database/templates/storage.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pg12-data-claim
+spec:
+  volumeName: pg12-data
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+# 10gb data volume on node with `db=true` label
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pg12-data
+  labels:
+    app: pg12
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  local:
+    path: /data/k8s/pg12
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: db
+          operator: In
+          values:
+          - "true"

--- a/apps/database/templates/storage.yaml
+++ b/apps/database/templates/storage.yaml
@@ -33,3 +33,33 @@ spec:
           operator: In
           values:
           - "true"
+---
+# NAS volume for backups
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pg12-backup-claim
+spec:
+  volumeName: pg12-backup
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pg12-backup
+  labels:
+    app: pg12
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  nfs:
+    server: nas
+    path: "/storage/k8s/nfs/pg12/backup"
+  mountOptions:
+    - nfsvers=4.2

--- a/apps/database/values.yaml
+++ b/apps/database/values.yaml
@@ -1,0 +1,13 @@
+pg12:
+  image:
+    tag: 12.9.0-debian-10-r62
+
+  replication:
+    enabled: false
+
+  persistence:
+    existingClaim: "pg12-data-claim"
+
+  primary:
+    nodeSelector:
+      db: "true"


### PR DESCRIPTION
Local volume and pods will run on node labeled `db=true`.

Every hour take a logical backup of pg12 and store the SQL on the NAS.  Dump filename includes the current hour so there are 24 backup "slots".