### PR TITLE
database: use preset random password for pg12

### DIFF
--- a/apps/database/Makefile
+++ b/apps/database/Makefile
@@ -1,0 +1,6 @@
+templates/pg12-creds.yaml:
+	$(info Use `kubectl -n database get secret pg12-creds -ojson | jq -r '.data."postgresql-password"' | base64 -d` to retrieve password.)
+	openssl rand -base64 15 \
+		| kubectl create secret generic -n database pg12-creds --dry-run=client --from-file=postgresql-password=/dev/stdin -o json \
+		| kubeseal --format yaml \
+		> templates/pg12-creds.yaml

--- a/apps/database/templates/backup_cronjob.yaml
+++ b/apps/database/templates/backup_cronjob.yaml
@@ -27,7 +27,7 @@ spec:
             - name: PGPASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: app-database-pg12
+                  name: pg12-creds
                   key: postgresql-password
             volumeMounts:
               - name: pg12-backup

--- a/apps/database/templates/pg12-creds.yaml
+++ b/apps/database/templates/pg12-creds.yaml
@@ -1,0 +1,16 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: pg12-creds
+  namespace: database
+spec:
+  encryptedData:
+    postgresql-password: AgCT6UQhQoqy39cDnCxlqDCjGFRhKZDSCfDfH5d2vJdDB+P/nGYDqA5jAFRW8sc+H/3F07OKlMXFL6QRMCnC1XFpSJr7R1ICf9g6A2bHTELAva3zhwYXwFX679ptwdpBumaFGDYJgnY6mPehHGg4iAbWMwR0TgplxPn06tF3+sLUbOvlGz36LnelsvEZrzeoefHhkU0WUFdNHrJc/poSsS3xqdJkkWN3+af9Za/zQQJANfpsoMcc8DUuVH2UtCX1LaLXegT2JBrDx9xEqjNJydeQxSQN4De5I9/77uykrUERgJyCvYC0ZtxDuXur4CcHq7ltF6EAQdFg7hlfLpycmqNmQqye+PKm/tXRPi+peQsqm4I6K1drMEDu4GJgvwm2sHpxQNDdeWsLBLlWfeNfxKBqVOTOW4NA7Qk8mGcI7FX3q0WMTxn/j40c3A3r8Sw6Azd9pu4XCs80J5gI8P8bo2C0Dfh7MDei2LjVKYLTCByRnl+d8DVrT7qcFFf57pAXahOOWPEQ2eAp+n/dJZqPlevFklqCOvw+eC4+yqkxeNyGQ3ndIrhMpJ9k19Fp96igVcROJHywRbYzdLQeISwDisgoZ6j3dKBa2Ad2jScqaxa5U5yljImKMb8/Sg8I2mJ0JQe3TWdNx9/N8YHiCuG3VkdSSqGsbsyCPRuK2c1Wta7tnGvkdsHkml+q8+1eBlkcsTApAeG9B8+dJ/G3dtOeLthptS02ooU=
+  template:
+    data: null
+    metadata:
+      creationTimestamp: null
+      name: pg12-creds
+      namespace: database
+

--- a/apps/database/values.yaml
+++ b/apps/database/values.yaml
@@ -1,6 +1,9 @@
 pg12:
   image:
     tag: 12.9.0-debian-10-r62
+    # debug: true
+
+  existingSecret: pg12-creds
 
   replication:
     enabled: false


### PR DESCRIPTION
Previously the `bitnami/postgresql` helm template was picking a random password.  That password ends up on the persistent data volume and can fall out-of-sync in circumstances where helm resets the k8s secret.  When that happens, the backup jobs will fail because their  password from the k8s secret is no longer honored.

Avoid the out-of-sync condition by just generating a password and manually creating the k8s secret.