### PR TITLE
database: set umask before database dump to tighten permissions

### DIFF
--- a/apps/database/templates/backup_cronjob.yaml
+++ b/apps/database/templates/backup_cronjob.yaml
@@ -22,7 +22,7 @@ spec:
             - /bin/sh
             args:
             - -c
-            - /opt/bitnami/postgresql/bin/pg_dumpall -h app-database-pg12 -U postgres > /backup/pg12_dump_$(date -u +%H).sql
+            - umask 0177 ; /opt/bitnami/postgresql/bin/pg_dumpall -h app-database-pg12 -U postgres > /backup/pg12_dump_$(date -u +%H).sql
             env:
             - name: PGPASSWORD
               valueFrom:


### PR DESCRIPTION
Using `0177` will make the SQL dump files `rw-------` (only user read/writeable) so they are less exposed on the NAS server.