### PR TITLE
database: expose pg12 outside of cluster

### DIFF
--- a/apps/database/values.yaml
+++ b/apps/database/values.yaml
@@ -24,3 +24,9 @@ pg12:
 
   volumePermissions:
     enabled: true  # needed to ensure correct permission for certificate files in `tls` section above
+
+  service:
+    type: LoadBalancer
+    loadBalancerIP: 172.22.18.33  # part of MetalLB private pool
+    port: 6432
+    externalTrafficPolicy: Local  # preserve client source IP to target pod


### PR DESCRIPTION
172.22.18.33:6432 will connect to the Postgres 12 server.

Might change from service with LoadBalancer to HAProxy TCP ingress later but keeping it simple for now.  Also hoping to preserve the source IP address of the psql clients, which will be tricky or impossible with a proxy (other than pgBouncer or similar).
