### PR TITLE
update cert-manager from 1.6.0 to 1.6.1

### DIFF
--- a/apps/cert-manager/kustomization.yaml
+++ b/apps/cert-manager/kustomization.yaml
@@ -4,5 +4,5 @@ metadata:
   name: cert-manager
 
 resources:
-  - https://github.com/jetstack/cert-manager/releases/download/v1.6.0/cert-manager.yaml
+  - https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
   - ./issuer-self-signed.yaml


### PR DESCRIPTION
Release notes:
https://github.com/jetstack/cert-manager/releases/tag/v1.6.1