### PR TITLE
monitoring: add PostgreSQL datasource for pg12 in Grafana

### DIFF
--- a/apps/database/templates/pg12-server-certificate.yaml
+++ b/apps/database/templates/pg12-server-certificate.yaml
@@ -8,6 +8,7 @@ spec:
   commonName: pg12
   dnsNames:
     - pg12
+    - app-database-pg12.database.svc
   privateKey:
     algorithm: ECDSA
   usages:

--- a/apps/monitoring/grafana-datasources.yaml
+++ b/apps/monitoring/grafana-datasources.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-datasources
+  namespace: monitoring
+stringData:
+  datasources.yaml: |-
+    apiVersion: 1
+    datasources:
+      - name: prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus-k8s.monitoring.svc:9090
+        editable: "false"
+        version: 1
+      - name: pg12
+        type: postgres
+        access: proxy
+        url: app-database-pg12.database.svc:6432
+        editable: "false"
+        version: 1
+        database: metrics
+        user: grafana
+        jsonData:
+          postgresVersion: 1200
+          tlsAuth: true
+          tlsAuthWithCACert: true
+          tlsSkipVerify: false
+          tlsConfigurationMethod: "file-path"
+          sslRootCertFile: /etc/grafana/certs/pg12/ca.crt
+          sslCertFile: /etc/grafana/certs/pg12/tls.crt
+          sslKeyFile: /etc/grafana/certs/pg12/tls.key
+          sslmode: "verify-full"
+          timescaledb: false
+          postgresVersion: 1200

--- a/apps/monitoring/grafana-pg12-client-certificate.yaml
+++ b/apps/monitoring/grafana-pg12-client-certificate.yaml
@@ -1,0 +1,19 @@
+# for Grafana datasource associated with the `pg12` database instance
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: grafana-pg12-client-certificate
+  namespace: monitoring
+spec:
+  secretName: grafana-pg12-client-cert
+  commonName: grafana
+  dnsNames:
+    - grafana
+  privateKey:
+    algorithm: ECDSA
+  usages:
+    - client auth
+
+  issuerRef:
+    name: cluster-ca
+    kind: ClusterIssuer

--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -65,6 +65,25 @@ patches:
       spec:
         template:
           spec:
+            initContainers:
+            - name: grafana-init-chmod-certs
+              image: busybox:1.35-musl
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -xc
+                - |
+                  cp /tmp/certs/* /etc/grafana/certs/
+                  chmod 400 /etc/grafana/certs/*.key
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 100Mi
+              volumeMounts:
+              - mountPath: /tmp/certs
+                name: grafana-pg12-client-cert-raw
+              - mountPath: /etc/grafana/certs
+                name: grafana-pg12-client-cert
             containers:
             - name: grafana
               env:
@@ -92,6 +111,9 @@ patches:
                 readOnly: false
               - name: sc-dashboard-volume
                 mountPath: "/grafana-dashboard-definitions/cm"
+              - name: grafana-pg12-client-cert
+                mountPath: /etc/grafana/certs/pg12
+                readOnly: true
             - name: grafana-sc-dashboard
               image: "kiwigrid/k8s-sidecar"
               imagePullPolicy: IfNotPresent
@@ -117,6 +139,17 @@ patches:
                 name: grafana-notifiers-brad
             - name: sc-dashboard-volume
               emptyDir: {}
+            - name: grafana-pg12-client-cert-raw
+              secret:
+                secretName: pg12-grafana-cert
+                defaultMode: 0400 # leading `0` is significant; yields octal value in yaml
+            - name: grafana-pg12-client-cert
+              emptyDir: {}
+
+  - path: grafana-datasources.yaml
+    target:
+      name: grafana-datasources
+      kind: Secret
 
   - patch: |-
       apiVersion: apps/v1


### PR DESCRIPTION
Create a `grafana` certificate and use it to connect to the `metrics` database on the pg12 server.  Had to repeat the same init container workaround for https://github.com/kubernetes/kubernetes/issues/57923 as used in #63.

Still working on the database setup and it will be documented in `apps/database/README.md` (or automated) later.  For now, using:

    -- base privileges
    \c postgres
    revoke connect on database postgres from PUBLIC;

    -- metrics database privileges
    create database metrics owner postgres;
    \c metrics
    revoke connect on database postgres from PUBLIC;
    revoke create on schema public from PUBLIC;

    create role metrics_readonly with password null nologin inherit;
    grant connect on database metrics to metrics_readonly;

    create role grafana password null login inherit;
    grant metrics_readonly to grafana;
    commit;