### PR TITLE
monitoring: mount service account token for grafana dashboard sidecar

### DIFF
--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -65,6 +65,7 @@ patches:
       spec:
         template:
           spec:
+            automountServiceAccountToken: true
             initContainers:
             - name: grafana-init-chmod-certs
               image: busybox:1.35-musl


### PR DESCRIPTION
After the kube-prometheus upgrade in #65, Grafana broke because the k8s-sidecar container that loads custom dashboards needs access to the service account token.  That access was removed in prometheus-operator/kube-prometheus#1591 .

A quick search did not turn up a simple way to only mount the token in one of the pod's containers (`k8s-sidecar`, not `grafana`), so we're mounting it for all containers in the pod instead.  Might be possible to tighten this up further.