### PR TITLE
database: port for pg12 `pg_dumpall` should be 6432 instead of 5432

### DIFF
--- a/apps/database/templates/backup-cronjob.yaml
+++ b/apps/database/templates/backup-cronjob.yaml
@@ -22,7 +22,7 @@ spec:
             - /bin/sh
             args:
             - -c
-            - umask 0177 ; /opt/bitnami/postgresql/bin/pg_dumpall -h app-database-pg12 -U postgres > /backup/pg12_dump_$(date -u +%H).sql
+            - umask 0177 ; /opt/bitnami/postgresql/bin/pg_dumpall -h app-database-pg12 -p 6432 -U postgres > /backup/pg12_dump_$(date -u +%H).sql
             env:
             - name: PGPASSWORD
               valueFrom:


### PR DESCRIPTION
Going back to PR #60, the service for pg12 is on port 6432.  This should fix the broken backups.