### PR TITLE
haproxy-ingress: add IngressClass for public and private HAProxy controllers

### DIFF
--- a/apps/haproxy-ingress/templates/ingress-class-private.yaml
+++ b/apps/haproxy-ingress/templates/ingress-class-private.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: haproxy-private
+spec:
+  controller: haproxy-ingress.github.io/controller

--- a/apps/haproxy-ingress/templates/ingress-class-public.yaml
+++ b/apps/haproxy-ingress/templates/ingress-class-public.yaml
@@ -1,0 +1,6 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: haproxy-public
+spec:
+  controller: haproxy-ingress.github.io/controller


### PR DESCRIPTION
Add `IngressClass` resources for each of the HAProxy controller instances.  These are preferred in the v1 ingress API over the `kubernetes.io/ingress.class` annotation.