### PR TITLE
gitlab-ce: install GitLab Community Edition

### DIFF
--- a/apps/gitlab-ce/Chart.yaml
+++ b/apps/gitlab-ce/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: gitlab-ce
+description: GitLab Community Edition continuous integration server.
+
+type: application
+version: 0.0.1
+
+dependencies:
+- name: gitlab
+  version: 5.7.2
+  repository: https://charts.gitlab.io/

--- a/apps/gitlab-ce/templates/gitlab-gitaly-storage.yaml
+++ b/apps/gitlab-ce/templates/gitlab-gitaly-storage.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: gitlab-gitaly-data
+  labels:
+    app: gitlab
+    volname: gitlab-gitaly-data
+spec:
+  capacity:
+    storage: 50Gi
+  accessModes:
+    - ReadWriteOnce
+  nfs:
+    server: nas
+    path: "/storage/k8s/nfs/gitlab/gitaly-data"
+  mountOptions:
+    - nfsvers=4.2

--- a/apps/gitlab-ce/templates/gitlab-migrations-dummy-secret.yaml
+++ b/apps/gitlab-ce/templates/gitlab-migrations-dummy-secret.yaml
@@ -1,0 +1,13 @@
+# This secret should not be needed because we're using mTLS auth with
+# the database.  However, many of the GitLab pods (`migrations`,
+# `webservice`, etc.) will will hang out in the `Init` phase until the
+# secret is ready.  There is probably a cleaner workaround, but for now
+# just create the expected secret with an empty value.
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-postgresql-password
+  namespace: {{ .Release.Namespace }}
+data:
+  postgresql-password: ""

--- a/apps/gitlab-ce/templates/gitlab-minio-storage.yaml
+++ b/apps/gitlab-ce/templates/gitlab-minio-storage.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: gitlab-minio-data
+  labels:
+    app: gitlab
+    volname: gitlab-minio-data
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  nfs:
+    server: nas
+    path: "/storage/k8s/nfs/gitlab/minio-data"
+  mountOptions:
+    - nfsvers=4.2

--- a/apps/gitlab-ce/templates/gitlab-pg12-client-certificate.yaml
+++ b/apps/gitlab-ce/templates/gitlab-pg12-client-certificate.yaml
@@ -1,0 +1,19 @@
+# for GitLab to connect to the `pg12` database instance
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Release.Name }}-pg12-client-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: gitlab-pg12-client-cert
+  commonName: gitlab
+  dnsNames:
+    - gitlab
+  privateKey:
+    algorithm: ECDSA
+  usages:
+    - client auth
+
+  issuerRef:
+    name: cluster-ca
+    kind: ClusterIssuer

--- a/apps/gitlab-ce/templates/gitlab-redis-storage.yaml
+++ b/apps/gitlab-ce/templates/gitlab-redis-storage.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: gitlab-redis-master-data
+  labels:
+    app: gitlab
+    volname: gitlab-redis-master-data
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  nfs:
+    server: nas
+    path: "/storage/k8s/nfs/gitlab/redis-master-data"
+  mountOptions:
+    - nfsvers=4.2

--- a/apps/gitlab-ce/values.yaml
+++ b/apps/gitlab-ce/values.yaml
@@ -1,0 +1,57 @@
+gitlab:
+  global:
+    edition: ce
+    gitlabVersion: 14.7.2
+    hosts:
+      domain:
+        k8s
+    ingress:
+      enabled: true
+      configureCertmanager: false
+      class: haproxy-private
+      provider: haproxy
+    psql:
+      host: app-database-pg12.database.svc
+      port: 6432
+      ssl:
+        secret: gitlab-pg12-client-cert
+        clientCertificate: tls.crt
+        clientKey: tls.key
+        serverCA: ca.crt
+    extraEnv:
+      PGSSLCERT: /etc/gitlab/postgres/ssl/client-certificate.pem
+      PGSSLKEY: /etc/gitlab/postgres/ssl/client-key.pem
+      PGSSLROOTCERT: /etc/gitlab/postgres/ssl/server-ca.pem
+  certmanager:
+    install: false
+  gitlab-runner:
+    # Must include data for `gitlab.k8s.crt`.
+    # See https://docs.gitlab.com/runner/install/kubernetes.html#providing-a-custom-certificate-for-accessing-gitlab
+    certsSecretName: app-gitlab-ce-wildcard-tls-chain
+  minio:
+    persistence:
+      volumeName: gitlab-minio-data
+  nginx-ingress:
+    enabled: false
+  postgresql:
+    install: false
+  prometheus:
+    install: false
+  redis:
+    master:
+      persistence:
+        matchLabels:
+          app: gitlab
+          volname: gitlab-redis-master-data
+  gitlab:
+    gitaly:
+      persistence:
+        matchLabels:
+          app: gitlab
+          volname: gitlab-gitaly-data
+    sidekiq:
+      resources:
+        # default requests are pretty chunky at 900m and 2G
+        requests:
+          cpu: 500m
+          memory: 1G


### PR DESCRIPTION
Install GitLab CE using external `pg12` Postgres instance.

The SQL to create and initialize the `gitlabhq_production` database is:

    create role gitlab with password null login;
    commit;
    create database gitlabhq_production owner gitlab;
    \c gitlabhq_production
    create extension if not exists btree_gist;
    create extension if not exists pg_trgm;
    commit;

Adds private ingress for the following URLs:

* https://gitlab.k8s/
* https://minio.k8s/
* https://registry.k8s/

Log in to GitLab as `root` with password from:

    kubectl -n gitlab-ce get secret app-gitlab-ce-gitlab-initial-root-password -o json | jq -r 'data.password'

minio credentials are available with:

     for k in accesskey secretkey; do
         echo -n "$k: "
         kubectl -n gitlab-ce get secret app-gitlab-ce-minio-secret -o json | jq -r ".data.$k"
     done