### PR TITLE
gitlab-ce: configure gitlab-runner to use internal CA root cert

### DIFF
--- a/apps/gitlab-ce/values.yaml
+++ b/apps/gitlab-ce/values.yaml
@@ -30,9 +30,12 @@ gitlab:
   certmanager:
     install: false
   gitlab-runner:
-    # Must include data for `gitlab.k8s.crt`.
-    # See https://docs.gitlab.com/runner/install/kubernetes.html#providing-a-custom-certificate-for-accessing-gitlab
-    certsSecretName: app-gitlab-ce-wildcard-tls-chain
+    # Normally used for `gitlab.k8s.crt` certificate, but abusing so our CA root
+    # cert is mounted in the runner pods for use with $CI_SERVER_TLS_CA_FILE.
+    certsSecretName: cluster-ca-root-cert
+    envVars:
+    - name: CI_SERVER_TLS_CA_FILE
+      value: "/home/gitlab-runner/.gitlab-runner/certs/cluster-ca-root.crt"
   minio:
     ingress:
       tls:


### PR DESCRIPTION
The docs around using self-signed certificates are fairly confusing, but a review of the [gitlab-runner source] revealed that `CI_SERVER_TLS_CA_FILE` is used during runner registration step.

Seems to be equivalent to [`tls-ca-file`] described in the [TLS docs], but had trouble getting it to work from the `runners` config.  And using the env var means we can keep the default runner template config from the helm chart and not worry about reconciling drift during upgrades.

Not seeing any helm values to mount secrets into the runner containers, so abusing `certsSecretName` to mount the CA root cert we need.

[gitlab-runner source]: https://gitlab.com/gitlab-org/gitlab-runner
[`tls-ca-file`]: https://gitlab.com/gitlab-org/gitlab-runner/-/blob/61ab4b3db815b193b2db52295909aee9d8ba03cf/common/config.go#L736
[TLS docs]: https://gitlab.com/gitlab-org/gitlab-runner/-/blob/61ab4b3db815b193b2db52295909aee9d8ba03cf/docs/configuration/tls-self-signed.md