### PR TITLE
gitlab-ce: allow GitLab ssh traffic to gitlab.k8s port 22

### DIFF
--- a/apps/gitlab-ce/values.yaml
+++ b/apps/gitlab-ce/values.yaml
@@ -64,6 +64,13 @@ gitlab:
         matchLabels:
           app: gitlab
           volname: gitlab-gitaly-data
+    gitlab-shell:
+      service:
+        annotations:
+          metallb.universe.tf/address-pool: private-pool
+          metallb.universe.tf/allow-shared-ip: private-main
+        loadBalancerIP: 172.22.18.32
+        type: LoadBalancer
     sidekiq:
       resources:
         # default requests are pretty chunky at 900m and 2G

--- a/apps/haproxy-ingress/values.yaml
+++ b/apps/haproxy-ingress/values.yaml
@@ -2,7 +2,11 @@ haproxy-ingress-private:
   controller:
     ingressClass: haproxy-private
     service:
+      annotations:
+        metallb.universe.tf/address-pool: private-pool
+        metallb.universe.tf/allow-shared-ip: private-main
       loadBalancerIP: 172.22.18.32
+      externalTrafficPolicy: Cluster
     stats:
       enabled: true
       port: 1936


### PR DESCRIPTION
Bind the gitlab-shell service, used push git changes over ssh, to 172.22.18.32.  The `allowed-shared-ip` annotation is needed to allow both HAProxy and SSH to share a single load balancer IP:
https://metallb.universe.tf/usage/#ip-address-sharing