### PR TITLE
haproxy-ingress: include `User-Agent` header in HTTP logs

### DIFF
--- a/apps/haproxy-ingress/values.yaml
+++ b/apps/haproxy-ingress/values.yaml
@@ -17,6 +17,9 @@ haproxy-ingress-private:
       enabled: true
     logs: # access logs
       enabled: true
+    config:
+      config-frontend: |
+        capture request header User-Agent len 100
 
 haproxy-ingress-public:
   controller:
@@ -33,3 +36,6 @@ haproxy-ingress-public:
       enabled: true
     logs: # access logs
       enabled: true
+    config:
+      config-frontend: |
+        capture request header User-Agent len 100


### PR DESCRIPTION
Per https://haproxy-ingress.github.io/docs/configuration/keys/#configuration-snippet and https://www.haproxy.com/blog/introduction-to-haproxy-logging/ .