### PR TITLE
gitlab-ce: upgrade from 14.7.2 to 14.8.2

### DIFF
--- a/apps/gitlab-ce/Chart.yaml
+++ b/apps/gitlab-ce/Chart.yaml
@@ -7,5 +7,5 @@ version: 0.0.1
 
 dependencies:
 - name: gitlab
-  version: 5.7.2
+  version: 5.8.2
   repository: https://charts.gitlab.io/

--- a/apps/gitlab-ce/values.yaml
+++ b/apps/gitlab-ce/values.yaml
@@ -1,7 +1,7 @@
 gitlab:
   global:
     edition: ce
-    gitlabVersion: 14.7.2
+    gitlabVersion: 14.8.2
     hosts:
       domain:
         k8s


### PR DESCRIPTION
Release 14.8.2 includes critical security for runner registration token disclosure:
https://about.gitlab.com/releases/2022/02/25/critical-security-release-gitlab-14-8-2-released/