### PR TITLE
cert-manager: upgrade from 1.6.1 to 1.7.1

### DIFF
--- a/apps/cert-manager/kustomization.yaml
+++ b/apps/cert-manager/kustomization.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cert-manager
 
 resources:
-  - https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
+  - https://github.com/jetstack/cert-manager/releases/download/v1.7.1/cert-manager.yaml
   - ./issuer-self-signed.yaml
   - ./issuer-cluster-ca.yaml
   - ./issuer-cluster-ca-signing-secret.yaml


### PR DESCRIPTION
Release notes:
https://github.com/cert-manager/cert-manager/releases/tag/v1.7.1