### PR TITLE
metallb: upgrade from 0.11.0 to 0.12.1

### DIFF
--- a/apps/metallb-system/kustomization.yaml
+++ b/apps/metallb-system/kustomization.yaml
@@ -4,5 +4,5 @@ metadata:
   name: metallb
 
 resources:
-  - github.com/metallb/metallb//manifests?ref=846c55af003807f1fe4066711607122456509fc4 # v0.11.0 tag
+  - github.com/metallb/metallb/manifests?ref=dbe1a20bb820e2b99337fd658ee40a2bbb53df42 # v0.12.1 tag
   - ./config.yaml


### PR DESCRIPTION
Release notes:

* https://metallb.universe.tf/release-notes/#version-0-12-1
* https://github.com/metallb/metallb/releases/tag/v0.12.1