### PR TITLE
vector-system: upgrade from 0.19.0 to 0.20.0

### DIFF
--- a/apps/vector-system/Chart.yaml
+++ b/apps/vector-system/Chart.yaml
@@ -3,16 +3,16 @@ name: vector
 description: Vector for log shipping to central store.
 
 type: application
-version: 0.0.1
+version: 0.0.2
 
-appVersion: "0.3.0"
+appVersion: "0.6.0"
 
 dependencies:
 - name: vector
   alias: vector-agent
-  version: 0.3.0
+  version: 0.6.0
   repository: https://helm.vector.dev
 - name: vector
   alias: vector-aggregator
-  version: 0.3.0
+  version: 0.6.0
   repository: https://helm.vector.dev


### PR DESCRIPTION
    $ helm show chart vector/vector | grep appVersion
    appVersion: 0.20.0-distroless-libc

Release notes:

* https://vector.dev/releases/0.20.0/
* https://github.com/vectordotdev/vector/releases/tag/v0.20.0