### PR TITLE
haproxy-ingress: limit connections to a small number

### DIFF
--- a/apps/haproxy-ingress/values.yaml
+++ b/apps/haproxy-ingress/values.yaml
@@ -20,6 +20,7 @@ haproxy-ingress-private:
     config:
       config-frontend: |
         capture request header User-Agent len 100
+      max-connections: "250"
 
 haproxy-ingress-public:
   controller:
@@ -39,3 +40,4 @@ haproxy-ingress-public:
     config:
       config-frontend: |
         capture request header User-Agent len 100
+      max-connections: "250"


### PR DESCRIPTION
Set [max-connections] to a small number to workaround startup issues caused by a limit of 4096 open file handles (`ulimit -a`).

By default, haproxy will calculate the number of open file sockets (file handles) it needs based on the number of backends (ingresses) it has.  Our workers currently have a soft limit of 1024 open file handles and hard limit of 4096.  With only 8 or 9 backends, the calculated `ulimit -a` value is 4099, which exceeds the hard limit and prevents haproxy from starting.

Eventually, it probably makes sense to install linux-pam on the worker nodes, or tweak the k0s startup scripts, to allow for more open file handles.  But for now just limit the maximum number of connections since we do not anticipate serving high levels of traffic.

[max-connections]: https://haproxy-ingress.github.io/docs/configuration/keys/#connection