### PR TITLE
music: install mopidy and snapcast-server for audio streaming

### DIFF
--- a/apps/music/kustomization.yaml
+++ b/apps/music/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: music
+
+resources:
+  - ./mopidy-service-account.yaml
+  - ./mopidy-deployment.yaml
+  - ./mopidy-service-web.yaml
+  - ./mopidy-service-snapcast-stream.yaml
+  - ./mopidy-service-snapcast-control.yaml
+  - ./mopidy-ingress.yaml

--- a/apps/music/mopidy-deployment.yaml
+++ b/apps/music/mopidy-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mopidy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mopidy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mopidy
+    spec:
+      containers:
+      - name: mopidy
+        image: ghcr.io/bfritz/mopidy:2022-03-12
+        imagePullPolicy: Always
+        args:
+        - -o
+        - http/hostname=0.0.0.0
+        - -o
+        - audio/output=audioresample ! audioconvert ! audio/x-raw,rate=48000,channels=2,format=S16LE ! tcpclientsink host=127.0.0.1 port=7777
+        ports:
+        - containerPort: 6680
+          name: http
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+      - name: snapcast-server
+        image: ghcr.io/bfritz/snapcast-server:2022-03-12
+        imagePullPolicy: Always
+        args:
+        - --stream.source="tcp://0.0.0.0:7777?name=default"
+        - --logging.filter="*:warning"
+        ports:
+        - containerPort: 1704
+          name: snapcast-stream
+        - containerPort: 1705
+          name: snapcast-ctrl
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 100 # mopidy
+        runAsGroup: 18 # audio
+      serviceAccountName: mopidy

--- a/apps/music/mopidy-ingress.yaml
+++ b/apps/music/mopidy-ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: cluster-ca
+  name: mopidy
+spec:
+  ingressClassName: haproxy-private
+  tls:
+  - secretName: mopidy-tls
+    hosts:
+    - music.k8s
+  rules:
+  - host: music.k8s
+    http:
+      paths:
+      - backend:
+          service:
+            name: mopidy-web
+            port:
+              name: http
+        path: /
+        pathType: Prefix

--- a/apps/music/mopidy-service-account.yaml
+++ b/apps/music/mopidy-service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mopidy

--- a/apps/music/mopidy-service-snapcast-control.yaml
+++ b/apps/music/mopidy-service-snapcast-control.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: mopidy
+  name: mopidy-snapcast-control
+spec:
+  type: NodePort
+  ports:
+  - name: snapcast-control
+    port: 1705
+    targetPort: snapcast-ctrl
+    nodePort: 31705
+  selector:
+    app.kubernetes.io/name: mopidy

--- a/apps/music/mopidy-service-snapcast-stream.yaml
+++ b/apps/music/mopidy-service-snapcast-stream.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: mopidy
+  name: mopidy-snapcast-stream
+spec:
+  type: NodePort
+  ports:
+  - name: snapcast-stream
+    port: 1704
+    targetPort: snapcast-stream
+    nodePort: 31704
+  selector:
+    app.kubernetes.io/name: mopidy

--- a/apps/music/mopidy-service-web.yaml
+++ b/apps/music/mopidy-service-web.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: mopidy
+  name: mopidy-web
+spec:
+  ports:
+  - name: http
+    port: 6680
+    targetPort: http
+  selector:
+    app.kubernetes.io/name: mopidy


### PR DESCRIPTION
Allows streaming of music, podcasts, and internet radio stations to [snapcast] clients, including one connected to a multi-channel amplifier and built-in speakers.

Follow-up PRs will configure access to a music library on NAS storage and an OPML list of podcast feeds.

The mopidy and snapcast-server images are built from [this repo] by GitHub actions.

[snapcast]: https://mjaggard.github.io/snapcast/
[this repo]: https://github.com/bfritz/dockerfiles