### PR TITLE
gitlab-ce: decrease min and max replica counts for webservice pod

### DIFF
--- a/apps/gitlab-ce/values.yaml
+++ b/apps/gitlab-ce/values.yaml
@@ -78,6 +78,9 @@ gitlab:
           cpu: 500m
           memory: 1G
     webservice:
+      hpa:
+        minReplicas: 1
+        maxReplicas: 3
       ingress:
         tls:
           secretName: gitlab-tls


### PR DESCRIPTION
Update `HorizontalPodAutoscaler` settings for the GitLab webservice pod to make it more likely for that pod to scale down to 1 replica.  Was annoying to always have 2 running for a small install as the HTTP request logs are split between the two.

Reduced maximum count from 10 to 3 as well given the small size of this cluster.