### PR TITLE
cert-manager, monitoring: removed old sealed secrets from kustomize

### DIFF
--- a/apps/cert-manager/kustomization.yaml
+++ b/apps/cert-manager/kustomization.yaml
@@ -7,4 +7,3 @@ resources:
   - https://github.com/jetstack/cert-manager/releases/download/v1.7.1/cert-manager.yaml
   - ./issuer-self-signed.yaml
   - ./issuer-cluster-ca.yaml
-  - ./issuer-cluster-ca-signing-secret.yaml

--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -6,7 +6,6 @@ metadata:
 resources:
   - github.com/bfritz/homelab-apps/vendor/kube-prometheus
   - ./alertmanager-ingress.yaml
-  - ./gotify-admin-password.yaml
   - ./gotify-deployment.yaml
   - ./gotify-ingress.yaml
   - ./gotify-service.yaml


### PR DESCRIPTION
Remove SOPS-encrypted secrets that used to be sealed secrets from
Kustomize files.  These secrets are now manually deployed to the
cluster.  Should have been included in PR #94.