### PR TITLE
extra: use `extra-*` naming pattern for apps in extra repo

### DIFF
--- a/apps/extra/apps.yaml
+++ b/apps/extra/apps.yaml
@@ -12,7 +12,7 @@ spec:
       - path: apps/*
   template:
     metadata:
-      name: 'app-{{path.basename}}'
+      name: 'extra-{{path.basename}}'
     spec:
       project: default
       destination:
@@ -24,5 +24,3 @@ spec:
         path: '{{path}}'
       syncPolicy:
         automated: {}
-        syncOptions:
-        - CreateNamespace=true


### PR DESCRIPTION
Will help avoid name conflicts with the base applications.

Also use manual namespace creation for the extra apps.