### PR TITLE
monitoring: mark the Prometheus datasource as default

### DIFF
--- a/apps/monitoring/grafana-datasources.yaml
+++ b/apps/monitoring/grafana-datasources.yaml
@@ -9,6 +9,7 @@ stringData:
     datasources:
       - name: prometheus
         type: prometheus
+        isDefault: true
         access: proxy
         url: http://prometheus-k8s.monitoring.svc:9090
         editable: "false"


### PR DESCRIPTION
Having some trouble provisioning dashboards and hoping
this change along with `datasource: null` in the JSON
might fix it per [this comment].  Even if it does not
fix the dashboard issue, prometheus should be the
default.

[this comment]: https://github.com/grafana/grafana/issues/12930#issuecomment-413196011