### PR TITLE
monitoring: use vendored kube-prometheus directly instead of via GitHub link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vendor/kube-prometheus"]
-	path = vendor/kube-prometheus
+	path = apps/monitoring/vendor/kube-prometheus
 	url = https://github.com/prometheus-operator/kube-prometheus.git
 	branch = main

--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -4,7 +4,7 @@ metadata:
   name: monitoring
 
 resources:
-  - github.com/bfritz/homelab-apps/vendor/kube-prometheus
+  - ./vendor/kube-prometheus/
   - ./alertmanager-ingress.yaml
   - ./gotify-deployment.yaml
   - ./gotify-ingress.yaml


### PR DESCRIPTION
Rather than have Kustomize make remote call to
https://github.com/bfritz/homelab-apps/vendor/kube-prometheus (always on
the `main` branch) to pull the kube-prometheus manifests, just use them
directly via the submodule directory.  Will help avoid confusion where
the kube-prom manifests are updated in a branch, the ArgoCD AppSet is
updated to that branch, but the kube-prom resources still do not update
because the GitHub link is still pointing to `main`.

Relocated the `vendor` directory under `apps/monitoring/` because
Kustomize will not load resources from parent directories for for
security reasons.