### PR TITLE
monitoring: update kube-prometheus and component versions

### DIFF
--- a/apps/monitoring/alertmanager-ingress.yaml
+++ b/apps/monitoring/alertmanager-ingress.yaml
@@ -23,3 +23,29 @@ spec:
               number: 9093
         path: /
         pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: alertmanager-allow-from-ingress
+  namespace: monitoring
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: haproxy-ingress
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: haproxy-ingress-private
+    ports:
+    - port: 9093
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: alert-router
+      app.kubernetes.io/instance: main
+      app.kubernetes.io/name: alertmanager
+      app.kubernetes.io/part-of: kube-prometheus
+  policyTypes:
+  - Ingress

--- a/apps/monitoring/grafana-ingress.yaml
+++ b/apps/monitoring/grafana-ingress.yaml
@@ -23,3 +23,28 @@ spec:
               number: 3000
         path: /
         pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: grafana-allow-from-ingress
+  namespace: monitoring
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: haproxy-ingress
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: haproxy-ingress-private
+    ports:
+    - port: 3000
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: grafana
+      app.kubernetes.io/name: grafana
+      app.kubernetes.io/part-of: kube-prometheus
+  policyTypes:
+  - Ingress

--- a/apps/monitoring/prometheus-ingress.yaml
+++ b/apps/monitoring/prometheus-ingress.yaml
@@ -23,3 +23,29 @@ spec:
               number: 9090
         path: /
         pathType: Prefix
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: prometheus-allow-from-ingress
+  namespace: monitoring
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: haproxy-ingress
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: haproxy-ingress-private
+    ports:
+    - port: 9090
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: prometheus
+      app.kubernetes.io/instance: k8s
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/part-of: kube-prometheus
+  policyTypes:
+  - Ingress


### PR DESCRIPTION
Update to `v0.11.0` tag of kube-prometheus.

    Component updates:

    * `alertmanager` 0.23.0 --> 0.24.0
    * `blackboxExporter` 0.19.0 --> 0.21.0
    * `grafana` 8.4.1 --> 8.5.5
    * `kubeStateMetrics` 2.3.0 --> 2.5.0
    * `prometheus` 2.33.3 --> 2.36.1
    * `prometheusOperator` 0.54.0 --> 0.57.0
    * `kubeRbacProxy` 0.11.0 --> 0.12.0
    * `pyrra` N/A --> 0.4.4

New `NetworkPolicy` manifests added to re-open UI access to alertmanager,
grafana, and prometheus from the HAProxy private instance.  Without the
new allow rules, access to the web interfaces is broken (HTTP 503 from
HAProxy).

Context in [issue #1719].

[issue #1719]: https://github.com/prometheus-operator/kube-prometheus/issues/1719