### PR TITLE
haproxy-ingress: upgrade from 0.13.6 to 0.13.9

### DIFF
--- a/apps/haproxy-ingress/Chart.yaml
+++ b/apps/haproxy-ingress/Chart.yaml
@@ -3,16 +3,16 @@ name: haproxy-ingress
 description: haproxy ingress controller
 
 type: application
-version: 13.6.0
+version: 13.9.0
 
-appVersion: "v0.13.6"
+appVersion: "v0.13.9"
 
 dependencies:
 - name: haproxy-ingress
   alias: haproxy-ingress-private
-  version: 0.13.6
+  version: 0.13.9
   repository: https://haproxy-ingress.github.io/charts
 - name: haproxy-ingress
   alias: haproxy-ingress-public
-  version: 0.13.6
+  version: 0.13.9
   repository: https://haproxy-ingress.github.io/charts


### PR DESCRIPTION
Release notes:
https://github.com/jcmoraisjr/haproxy-ingress/releases/tag/v0.13.9 https://github.com/jcmoraisjr/haproxy-ingress/blob/master/CHANGELOG/CHANGELOG-v0.13.md#v0139