### PR TITLE
argocd, monitoring: rotate sops secrets

### DIFF
--- a/apps/argocd/extra-repository-credentials.yaml.enc
+++ b/apps/argocd/extra-repository-credentials.yaml.enc
@@ -6,10 +6,10 @@ metadata:
     labels:
         argocd.argoproj.io/secret-type: repository
 stringData:
-    type: ENC[AES256_GCM,data:Ygdr,iv:LECncmSQursxsi2oOt1sI+3OTCl4+0Pupa21fIutG48=,tag:yEXDchImqfV5r7fyMjz9cA==,type:str]
-    url: ENC[AES256_GCM,data:Bx2nDdSEBAu5ZdU3W3ndan/fSRLeTvQmoMOGh6GxYbh6q9BV05jzF6FU+kgZq8Y=,iv:15JJFe0WblQLXydHKJpFN+llruva4K+6rFmuA+FKphk=,tag:NkuZKkBCrpEgZ9b0pt3LmQ==,type:str]
-    username: ENC[AES256_GCM,data:rBXMfJmE,iv:nwc9+6+8pXBx2AcQ7xHh6qJezjf1Ew3b6TGXAoY2Bcw=,tag:VTXuodPoSlXsOwwlYPKw/w==,type:str]
-    password: ENC[AES256_GCM,data:acMik1i3hjHnTGMhLi84Jq25T2vPn7nNWEg=,iv:nNPlBqW3WRz1CNMa9+GdQZGoYAGUeRdD4wLKB+kANOw=,tag:p40Mg8TPdD5jV7uw0Lcwlg==,type:str]
+    type: ENC[AES256_GCM,data:tujp,iv:RJvUi5NHnZYQN90ToumeqcYmPPMtFGh8rCoGT4LAvB4=,tag:tO9uix/aXFDcTtsV7KknuA==,type:str]
+    url: ENC[AES256_GCM,data:1pbunGil6EOr61EqPDALnlGh78K/qh9ob670B0kqSu1B0prFbSYXa5gRUzEq+FE=,iv:sVB6n7Y1pP0wdwpV2h8cgErKOQBW0mN4sCPR6B5WEjk=,tag:REyThlFoyhrL3DOQIi5NlA==,type:str]
+    username: ENC[AES256_GCM,data:wLPKRtdN,iv:P6JKvkfaXT9GyyM4HakUQ3Aa8pI13GuYAqaAooWvwU8=,tag:sqS3C5qo0k+PI9j2ouu03A==,type:str]
+    password: ENC[AES256_GCM,data:aFTHE6vFExaE1c+ir8mmaxgn9ZYEF35Xs5E=,iv:QBHoaXCa4h+YfZi1Np2x9v9Z2kNcL0WylitCqZ2s2Cc=,tag:gC9IoFpTZvrKNJT9LUl6Zg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -19,14 +19,14 @@ sops:
         - recipient: age16a2rje3pq2hns5g2dnd0nnwxu5rkam4885mk2hfcr0fs2v8444dqqjrtl9
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByWnNwUVhzS21QaDhzZXZG
-            VndlanFwY1EwOVo5ZzJnOTRUejdGaFJLTjNBClV2aG1ubm4vUEFvWTE3YTA0dytE
-            ZE5yeEs5NTNuZzk1b3BxNDhCTSt5Z00KLS0tIEZQZGo0ZTU3b3JZL3JLcE40VnNK
-            eTdYRHdkV1EvVmd0anRodkpJTm9sb0EKV5IK070RACOOt+cGG4DF0k/7UFqD3U/6
-            SOmdk14W0PZjHW9AxvI53+Dw+uyuYdldBNiQG9MTk7TEyy3cbUXVDw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvK1ZFaGVkUTlRZjZycE1q
+            THIxcUh6YittWmhDMXpTeFNNalIydlpReXdzCjVXL1dOT2VGNmpYRk9qbkY4S3pn
+            bzBXTGRwdlpWcU1OTDZmMmx4K2ZQNkkKLS0tIHYzMUFZb1JSUklJcHNvUm9VVmw2
+            ejJYOEl4eDg5UHYrdzNKMEV2ZGpGc00KVJcMbfsmT7mye/xJ9eDT4yOrARQM2bhp
+            Ubli+eZkCMVvjqlm9j41TtfbiqtQ4PnJQjc10jM/YWdOAo5PKyfqjg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-08-15T02:01:10Z"
-    mac: ENC[AES256_GCM,data:9H5n1WClgrTJxSQJWeacn0YeZ0YkWlfQoGlGK4XlUbEWDliiRp5mHG5LX3cQVhL4XmwHoXfa8AvBcUrYoDvnmXOqsGcNXi9yer8tGLjqjltphYsjYLNgRhPhjS2HYAFgDG70KI9Tcj7TFwk41DzecQvQiOie5vaaRxQJ/V0F7YA=,iv:NJYy1pJ9vF9PtpF5yPiNE2wvqPIygInP6lDzNoDO58U=,tag:X685oBsMrHXmG/08cAvF+g==,type:str]
+    lastmodified: "2022-12-12T04:13:43Z"
+    mac: ENC[AES256_GCM,data:G4mrZdBVAix7pZq/SXC71FMcXHO3HwniHE9/NtWj28wp40P6RsgpfSnVECDJAYV+RDuf79MV0IK+pmpv8sPos5MP7NMASpyarjgJNLa7dcuSqNM/hjGR4Zz2e8GgqGRAJG8FoIUYTlRm9BngT/voifEhX0bCWnHTlM3tfqDxvAQ=,iv:b6mO650Vh7c4WF3zBWDVE5Ba85DOViRmjVgTPHi0BoY=,tag:YaJc682smU6QHe8+/KBkfw==,type:str]
     pgp: []
-    encrypted_regex: ^(data|stringData)$
+    encrypted_regex: ^(data|stringData|tls.crt|tls.key)$
     version: 3.7.3

--- a/apps/monitoring/gotify-admin-password.yaml.enc
+++ b/apps/monitoring/gotify-admin-password.yaml.enc
@@ -1,10 +1,11 @@
 apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:qU1zFMEmf+e656vf+2eor2XlpvEAnGoe61/wNQ==,iv:ZIpPh+eXo8LOeDfc6UgDPw3aJML5R+2HvUUt+JF6biY=,tag:SVNgO5hyiPdX5+ju5lVjPQ==,type:str]
 kind: Secret
 metadata:
+    creationTimestamp: null
     name: gotify-admin
     namespace: monitoring
-data:
-    password: ENC[AES256_GCM,data:s2HkZlbXnRrV8zFNaxQ69BWrE0t1souvx0lyIw==,iv:FxKxQKGnm4B50LNG+GjqA9c/dYtkl52K1R49rBv5Wig=,tag:e0biC0tj0fNjvIliPdLhwQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -14,14 +15,14 @@ sops:
         - recipient: age16a2rje3pq2hns5g2dnd0nnwxu5rkam4885mk2hfcr0fs2v8444dqqjrtl9
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvM0o0M3V1ZDk2dlUwdWdz
-            a2xNQ2hhRVhDOHNVTzd6anNaL1F4UDY1a21FCjg4MGhGSWM4Qmx0T3hFMDIrSU1W
-            T2NpdjlzMDk4cHBWSlhHYmxEKzVDTnMKLS0tIFoxa2xJOXVEak9ueUtEZ2h0ZUJS
-            QXNNbnppQjJhVTE1bUdYRjVzdVllVUEKkd4Z1LWshsqMDeuj/65LtLAGqKCbwb/j
-            hPWVsBY1WCGw+hjFd8RTLiJvRNcjJq5tSzBX5u67NHT9B4in7b4NhA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPdENqdHRiZG16MVczTTk1
+            dzdiL3dTZkhhM1NEWVIxMXdDT1NQR1MzMldFClZaNThOdVNJUm1LS09LWXdvSllt
+            d2Fla1kyMzV3ZzhuNmZTcGIwcjlJYUEKLS0tIG1Eb3V0RVpjRlAxSEdpVktpekxJ
+            VXFIT3VJN0RPdmFQaHJYWVZYbUgzSlkK2N1IMXhysCMeYflN5A26PjrrebxXWHTO
+            mYmFLL3LW7CdenKtxb4Jq9oEUnk6pCeR2dgVxjlf7PYVHkMwWNYSeg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-08-15T02:03:36Z"
-    mac: ENC[AES256_GCM,data:fQFjrSLY/mxoiMty9WaqREaEORih4mfHSzASBDngJPWVFN9pq/U9jFyNlLwC1okejNO3YNzTYEcroIXygt9xIkyvA4JDT0tdSgB/CN1P+NP3CdzbcmxXYmxprEEUykxX/mgrK7HoLO2vPJOmV3nWkALW5eahH6XlybQtsp1oVlo=,iv:C+IXVCaCL1FaRjOmPVOAkncvPgW+M8Wn/LclzbwdwcQ=,tag:PcZMIlE8AVcsRC/Z7I52eg==,type:str]
+    lastmodified: "2022-12-12T04:15:54Z"
+    mac: ENC[AES256_GCM,data:HF7X+VO35Xpn1sP3OiFs/SOgqzxUcNMoeU3b+vQZdoGP/SqVyn/EDFvZvis46ZCaShFfW7D/toRxeskrOTbp2QdRT9hcrEj1J+owa18dY4N1kQ4/Va3frMJ1mHkA2lIA2vKQ1ZiMN0VBV/lg5Adv49kaHo0SOUHE3KON5d9M01I=,iv:+osgZyOca4TnfO3z1CQAcdsId1dkSzbMebdqWtpPHEw=,tag:IgqH6i5BonsHl5xHzBq42Q==,type:str]
     pgp: []
-    encrypted_regex: ^(data|stringData)$
+    encrypted_regex: ^(data|stringData|tls.crt|tls.key)$
     version: 3.7.3


### PR DESCRIPTION
Update a couple of secrets that were not applying properly.

Re-encrypted with:

    sops --encrypt --encrypted-regex '^(data|stringData|tls.crt|tls.key)$' \
        --input-type yaml --output-type yaml \
        --age="age16a2rje3pq2hns5g2dnd0nnwxu5rkam4885mk2hfcr0fs2v8444dqqjrtl9" \
        [input file] > [output file]