### PR TITLE
update to actions/checkout@v3 to fix warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: lint
         run: make lint


### PR DESCRIPTION
Fixes warning:

> Node.js 12 actions are deprecated. Please update the following
> actions to use Node.js 16: actions/checkout@v2. For more
> information see:
> https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.