### PR TITLE
monitoring: scale down prometheus to single node to avoid sharding

### DIFF
--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -32,6 +32,17 @@ images:
     digest: sha256:2029752d7596ec30b65f1ce07bad9af1cdbb6cf7013fcc1f5720f4bf7c4b61e1 # 1.15.4
 
 patches:
+  # configure single replica for prometheus server
+  - patch: |-
+      apiVersion: monitoring.coreos.com/v1
+      kind: Prometheus
+      metadata:
+        name: k8s
+        namespace: monitoring
+      spec:
+        replicas: 1
+
+  # configure additional scrape targets for prometheus server
   - patch: |-
       apiVersion: monitoring.coreos.com/v1
       kind: Prometheus

--- a/apps/monitoring/prometheus-storage.yaml
+++ b/apps/monitoring/prometheus-storage.yaml
@@ -14,20 +14,3 @@ spec:
     path: "/storage/k8s/nfs/prometheus/a"
   mountOptions:
     - nfsvers=4.2
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: prometheus-storage-b
-  labels:
-    app: prometheus
-spec:
-  capacity:
-    storage: 50Gi
-  accessModes:
-    - ReadWriteOnce
-  nfs:
-    server: nas
-    path: "/storage/k8s/nfs/prometheus/b"
-  mountOptions:
-    - nfsvers=4.2


### PR DESCRIPTION
Homelab setup is not big enough to require multiple prometheus server pods[1].  Currently seeing cases where querying for a given metric, e.g. `probe_duration_seconds`, will return expected metrics during one request and an empty array on the next as haproxy round robins the queries between two prometheus pods.

[1] https://www.robustperception.io/scaling-and-federating-prometheus/