### PR TITLE
argocd: rotate sops secrets

### DIFF
--- a/apps/argocd/extra-repository-credentials.yaml.enc
+++ b/apps/argocd/extra-repository-credentials.yaml.enc
@@ -6,10 +6,10 @@ metadata:
     labels:
         argocd.argoproj.io/secret-type: repository
 stringData:
-    type: ENC[AES256_GCM,data:tujp,iv:RJvUi5NHnZYQN90ToumeqcYmPPMtFGh8rCoGT4LAvB4=,tag:tO9uix/aXFDcTtsV7KknuA==,type:str]
-    url: ENC[AES256_GCM,data:1pbunGil6EOr61EqPDALnlGh78K/qh9ob670B0kqSu1B0prFbSYXa5gRUzEq+FE=,iv:sVB6n7Y1pP0wdwpV2h8cgErKOQBW0mN4sCPR6B5WEjk=,tag:REyThlFoyhrL3DOQIi5NlA==,type:str]
-    username: ENC[AES256_GCM,data:wLPKRtdN,iv:P6JKvkfaXT9GyyM4HakUQ3Aa8pI13GuYAqaAooWvwU8=,tag:sqS3C5qo0k+PI9j2ouu03A==,type:str]
-    password: ENC[AES256_GCM,data:aFTHE6vFExaE1c+ir8mmaxgn9ZYEF35Xs5E=,iv:QBHoaXCa4h+YfZi1Np2x9v9Z2kNcL0WylitCqZ2s2Cc=,tag:gC9IoFpTZvrKNJT9LUl6Zg==,type:str]
+    type: ENC[AES256_GCM,data:/JXG,iv:la9vpswc5aD5cHsKJkiGSI2N+3bDqaecsMXULQW8DSA=,tag:HOrngVgMaOVxfzF7epeBlg==,type:str]
+    url: ENC[AES256_GCM,data:L1z8DBC0t+DWalE1Jry1kSbL6SGMssdY1b9fNm14eMp9FMhF3ZFPwTcveYbWdvs=,iv:o9Gvp7cCZpeHy9Gkmrk3m5SiwR70bN6vbhSD+r2wnxo=,tag:Zibox3B+oKzXvMuwxXymzw==,type:str]
+    username: ENC[AES256_GCM,data:MqZMxHBf,iv:qxue9TL4urmHN5QRBzG6HjWmQ1SNhEstjgveMjD1Yns=,tag:Er8K+/gd+EWd2EMxMrdukg==,type:str]
+    password: ENC[AES256_GCM,data:P4sOFYI4SWi7C9jn3UUKBTpAoM8USIvKhcw=,iv:JXoBIxLZp33RfJ4IxBjL2B8eq/mWObylx6p8LPqrL4c=,tag:JWxb18W6wOGBrAvceQAOrg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -19,14 +19,14 @@ sops:
         - recipient: age16a2rje3pq2hns5g2dnd0nnwxu5rkam4885mk2hfcr0fs2v8444dqqjrtl9
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvK1ZFaGVkUTlRZjZycE1q
-            THIxcUh6YittWmhDMXpTeFNNalIydlpReXdzCjVXL1dOT2VGNmpYRk9qbkY4S3pn
-            bzBXTGRwdlpWcU1OTDZmMmx4K2ZQNkkKLS0tIHYzMUFZb1JSUklJcHNvUm9VVmw2
-            ejJYOEl4eDg5UHYrdzNKMEV2ZGpGc00KVJcMbfsmT7mye/xJ9eDT4yOrARQM2bhp
-            Ubli+eZkCMVvjqlm9j41TtfbiqtQ4PnJQjc10jM/YWdOAo5PKyfqjg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpdDh3Rkp6NlNKY3JlM2V6
+            a1VySFUrMXJ2RHdjTjV3N1IrRzZVVW1FZ0VVCjYrUTFlNU5hNWZEZmlwekZOeWhw
+            WWtRSTJxOTNzc2hnazFuMW5TNkpja1UKLS0tIHp2OU1GTkJZRysyNWRJQUVtUGtY
+            Z0p5QW9mZnhWaHVBTGRNeVhETmpZYXcK8S0OblbP7Be4SE8l6MAAbv6Hx5wryEuA
+            Ma0IrGbm9tKGEYzTPbBDlBF3nCHcPqtnwXwa5u6deJmLisYQOu3zhw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-12-12T04:13:43Z"
-    mac: ENC[AES256_GCM,data:G4mrZdBVAix7pZq/SXC71FMcXHO3HwniHE9/NtWj28wp40P6RsgpfSnVECDJAYV+RDuf79MV0IK+pmpv8sPos5MP7NMASpyarjgJNLa7dcuSqNM/hjGR4Zz2e8GgqGRAJG8FoIUYTlRm9BngT/voifEhX0bCWnHTlM3tfqDxvAQ=,iv:b6mO650Vh7c4WF3zBWDVE5Ba85DOViRmjVgTPHi0BoY=,tag:YaJc682smU6QHe8+/KBkfw==,type:str]
+    lastmodified: "2023-07-23T20:28:33Z"
+    mac: ENC[AES256_GCM,data:BrZ8axg7UmO5wVtUUzmT8XmgCzuX2b5THYjKrV1bhXLIAd2WDamz/LSnDv8DX0/QycugAQW98ORPhN1rSfYOurA8ceer2pj+4qwP5tgq9rUYeu01B0vld1oGZ1wLqimton3c8ehbrFt4RtJX/FUQ9KoJJ14yWDMi+rSjiA7TeCQ=,iv:vEyZHvJpRIDeoFPXHjA9JRQV6CFhFC9o5vLc14hEM4E=,tag:HZX6DCirQ+7yhUN//PoyuQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData|tls.crt|tls.key)$
     version: 3.7.3


### PR DESCRIPTION
Update ArgoCD password for connecting to the extra application git repository.

Re-encrypted with:

    sops --encrypt --encrypted-regex '^(data|stringData|tls.crt|tls.key)$' \
        --input-type yaml --output-type yaml \
        --age="age16a2rje3pq2hns5g2dnd0nnwxu5rkam4885mk2hfcr0fs2v8444dqqjrtl9" \
        [input file] > [output file]