### PR TITLE
monitoring: fire alerts when Blackbox exporter probes fail

### DIFF
--- a/apps/monitoring/blackbox-exporter-probe-alerts.yaml
+++ b/apps/monitoring/blackbox-exporter-probe-alerts.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: probe-prometheus-rules
+  namespace: monitoring
+spec:
+  groups:
+  - name: probe.rules
+    rules:
+    - alert: EndpointDown
+      annotations:
+        summary: "Endpoint {{ $labels.instance }} down"
+      expr: probe_success == 0
+      for: 2m
+      labels:
+        severity: critical


### PR DESCRIPTION
Add new `EndpointDown` alert in `probe.rules` group to fire alerts when probes fail.