### PR TITLE
monitoring: add `http_401` module to blackbox exporter

### DIFF
--- a/apps/monitoring/blackbox-exporter-configuration.yaml
+++ b/apps/monitoring/blackbox-exporter-configuration.yaml
@@ -15,6 +15,12 @@ data:
           "method": "POST"
           "preferred_ip_protocol": "ip4"
         "prober": "http"
+      http_401:
+        http:
+          preferred_ip_protocol: "ip4"
+          valid_status_codes:
+            - 401
+        prober: http
       "irc_banner":
         "prober": "tcp"
         "tcp":


### PR DESCRIPTION
Allow for successful probes to services that require authentication for all endpoints.